### PR TITLE
Add CI with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language:
+   - python
+python:
+   - "2.7"
+   - "3.3"
+   - "3.4"
+   - "3.5"
+   - "pypy"
+install:
+   - pip install codecov
+   - pip install .
+script:
+   - python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 verbosity=2
 detailed-errors=1
 with-coverage=1
-cover-package=nose
+cover-package=pyasn
 
 # --------------------------------------------------------------
 # Uncomment the following if you want to use the pdb debugger to


### PR DESCRIPTION
fixes hadiasghari/pyasn#33

No fancy things like coverage and pep8 yet, but it works :) (for the first we cannot use the nosetests executable, as the c-code is not available then and we need to add this to the test_suite. For the last lot's of fixes are needed beforehand).

See a successful build here: https://travis-ci.org/sebix/pyasn/builds/159705563

You of course need to activate travis-ci for you repo