### PR TITLE
fixed socket import error on windows

### DIFF
--- a/pyasn/mrtx.py
+++ b/pyasn/mrtx.py
@@ -35,16 +35,21 @@ Other objects:
 """
 
 from __future__ import print_function, division
-from socket import inet_ntoa, inet_aton, inet_ntop, AF_INET, AF_INET6
+from socket import inet_ntoa, inet_aton, AF_INET, AF_INET6
 from struct import unpack, pack
 from time import time, asctime
 from sys import stderr, version_info
 try:
     from collections import OrderedDict
-except:
+except ImportError:
     # python 2.6 support - needs the ordereddict module
     from ordereddict import OrderedDict
 
+try:
+    from socket import inet_ntop
+except ImportError:
+    pass #inet_ntop is only available on unix
+    
 IS_PYTHON2 = (version_info[0] == 2)
 
 


### PR DESCRIPTION
-added explicit exception to OrderedDict import
-wrapped inet_ntop import in try/except

running the command `python .\pyasn_util_convert.py --single rib.20161208.2200.bz2 asn_db` wouldn't work on Windows. However it does work w/ the change I am proposing. You still won't be able to use the `MrtTableDump2` class on Windows, which as far as I can tell is the only thing that uses `inet_ntop`.