### PR TITLE
Update ASN bogus: add 0 and allow 64198-64495

### DIFF
--- a/pyasn/mrtx.py
+++ b/pyasn/mrtx.py
@@ -230,7 +230,9 @@ def is_asn_bogus(asn):
     #       WHOIS: https://github.com/rfc1036/whois   -- in the program source
     #       CIDR-Report: http://www.cidr-report.org/as2.0/reserved-ases.html
     # Note that the full list of unallocated and bogus ASNs is long, and changes; we use the basic
-    if 64198 <= asn <= 131071 or asn >= 4200000000:   # reserved & private-use-AS
+    if asn == 0:
+        return True
+    if 64496 <= asn <= 131071 or asn >= 4200000000:   # reserved & private-use-AS
         return True
     if asn >= 1000000:  # way above last allocated block (2014-11-02) -- might change in future
         return True

--- a/pyasn/mrtx.py
+++ b/pyasn/mrtx.py
@@ -230,7 +230,7 @@ def is_asn_bogus(asn):
     #       WHOIS: https://github.com/rfc1036/whois   -- in the program source
     #       CIDR-Report: http://www.cidr-report.org/as2.0/reserved-ases.html
     # Note that the full list of unallocated and bogus ASNs is long, and changes; we use the basic
-    if asn == 0:
+    if asn <= 0:
         return True
     if 64496 <= asn <= 131071 or asn >= 4200000000:   # reserved & private-use-AS
         return True


### PR DESCRIPTION
This here is the up to date list of the assigned ASN https://www.iana.org/assignments/as-numbers/as-numbers.xhtml
Currently 64198-64495 would be blocked, but those ASN are already in use.

64198-64296 	Assigned by ARIN 	whois.arin.net 	https://rdap.arin.net/registry
http://rdap.arin.net/registry 		2015-04-29
64297-64395 	Assigned by APNIC 	whois.apnic.net 	https://rdap.apnic.net/ 		2016-05-25
64396-64495 	Assigned by RIPE NCC 	whois.ripe.net 	https://rdap.db.ripe.net/ 		2016-07-29
64496-64511 	Reserved for use in documentation and sample code 			[RFC5398] 	2008-12-03
64512-65534 	Reserved for Private Use 			[RFC6996] 	
65535 	Reserved 			[RFC7300]