### PR TITLE
DOC: Use new pypi.org URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ pyasn
 =====
 
 .. image:: https://pypip.in/v/pyasn/badge.png
-   :target: https://pypi.python.org/pypi/pyasn
+   :target: https://pypi.org/project/pyasn/
 
 .. image:: https://pypip.in/d/pyasn/badge.png
-   :target: https://pypi.python.org/pypi/pyasn
+   :target: https://pypi.org/project/pyasn/
 
 
 **pyasn** is a Python extension module that enables very fast IP address to Autonomous System Number lookups.


### PR DESCRIPTION
pypi.python.org will be shutdown at 30th April: https://pyfound.blogspot.com/2018/03/warehouse-all-new-pypi-is-now-in-beta.html