### PR TITLE
switch to http for download

### DIFF
--- a/pyasn-utils/pyasn_util_asnames.py
+++ b/pyasn-utils/pyasn_util_asnames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2016 Italo Maia
 #

--- a/pyasn-utils/pyasn_util_convert.py
+++ b/pyasn-utils/pyasn_util_convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2009-2017 Hadi Asghari
 #


### PR DESCRIPTION
This builds on top of #72 and supports downloading via HTTPS instead of the deprecated and insecure FTP variant.

A minor additional change is that we should not hardcode `/usr/bin/python` in the shebang lines but instead let the enironment decide which Python version to use.