### PR TITLE
Fix regex import warning and make regex match on full pattern

### DIFF
--- a/pyasn/__init__.py
+++ b/pyasn/__init__.py
@@ -240,8 +240,8 @@ class pyasn(object):
         :param asdot:  "AS[Number].[Number]" representation of an autonomous system
         :return: 32bit AS number
         """
-        pattern = re.compile("^[AS]|[as]|[aS]|[As]][0-9]*(\.)?[0-9]+")
-        match = pattern.match(asdot)
+        pattern = re.compile(r'^(AS|as|aS|As)[0-9]+(\.[0-9]+)?')
+        match = pattern.fullmatch(asdot)
         if not match:
             raise ValueError("Invalid asdot format for input. input format must be something like"
                              " AS<Number> or AS<Number>.<Number> ")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -99,10 +99,11 @@ class TestSimple(TestCase):
         self.assertEqual(131393, pyasn.convert_asdot_to_32bit_asn("AS2.321"))
 
     def test_as_number_convert_fail(self):
-        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS]2.321")
-        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS2..321")
-        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS2.")
-        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS.098")
+        msg = "Invalid asdot format for input. input format must be something like AS<Number> or AS<Number>.<Number> "
+        self.assertRaisesRegex(ValueError, msg, pyasn.convert_asdot_to_32bit_asn, "AS]2.321")
+        self.assertRaisesRegex(ValueError, msg, pyasn.convert_asdot_to_32bit_asn, "AS2..321")
+        self.assertRaisesRegex(ValueError, msg, pyasn.convert_asdot_to_32bit_asn, "AS2.")
+        self.assertRaisesRegex(ValueError, msg, pyasn.convert_asdot_to_32bit_asn, "AS.098")
 
     def test_get_tud_prefixes(self):
         """

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -82,7 +82,7 @@ class TestSimple(TestCase):
         self.assertEqual(None, prefix)
         # todo: check that self.ipdb.lookup_asn('300.3.4.4') raises expcetion
 
-    def test_as_number_convert(self):
+    def test_as_number_convert_success(self):
         """
             Tests for correct conversion between 32-bit and ASDOT number formats for ASNs
         """
@@ -97,6 +97,12 @@ class TestSimple(TestCase):
         self.assertEqual(4294967295, pyasn.convert_asdot_to_32bit_asn("AS65535.65535"))
         self.assertEqual(0, pyasn.convert_asdot_to_32bit_asn("AS0"))
         self.assertEqual(131393, pyasn.convert_asdot_to_32bit_asn("AS2.321"))
+
+    def test_as_number_convert_fail(self):
+        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS]2.321")
+        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS2..321")
+        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS2.")
+        self.assertRaises(ValueError, pyasn.convert_asdot_to_32bit_asn, "AS.098")
 
     def test_get_tud_prefixes(self):
         """


### PR DESCRIPTION
## Issue
Importing `pyasn` would give a warning with the message `SyntaxWarning: invalid escape sequence '\.'`

Further inspection showed that the regex was also not working as intended.

## Summary of Changes

This fixes the `SyntaxWarning: invalid escape sequence '\.'` import warning caused by not using a raw string for the regex string.  The pattern is now defined in a raw string.

After digging a little deeper, I found that the regex needed a little work as well.  It was returning a match only on the first occurrence of the letters `"A"` or `"S"`.  I've updated the regex with corrected syntax and changed to using `fullmatch` instead of `match`.  `match` will provide a match object on a partial match, but `fullmatch` only matches on the full regex pattern.  This fixes an issue where `match` currently returns a partial match, which means the intended exception will not be thrown on improperly formatted strings.  Now, that exception should be thrown in all intended cases.

I ran the existing tests and they still pass, so previously expected strings still give the proper response.  I've also added tests for failure cases.  For the failure cases, I ensured that the ValueError message matches the expected message.  The reason for that is invalid strings that passed the match check would also end up raising a ValueError, but during the conversion to an int.  I could create a new error to raise instead of checking the error message which is a bit nicer imo.  Let me know if you have a preference.

This shouldn't produce any very noticeable change in behavior from a user's perspective, as it's still producing the same exception types.  It should really just fail a bit more cleanly with the stricter format checking.